### PR TITLE
Map host X11 to container for Ubuntu WSL

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -25,6 +25,7 @@ services:
       - ~/.Xauthority:/root/.Xauthority
       - /etc/localtime:/etc/localtime:ro
       - ./logs:/usr/src/plato/logs
+      - /tmp/.X11-unix:/tmp/.X11-unix
     develop:
       watch:
         - action: sync+restart


### PR DESCRIPTION
This will allow the emulator to display in Windows when running the container in WSL2 with the default Ubuntu distribution.

Context: https://github.com/microsoft/wslg/blob/d14b39219b8250ae610bf4010b6cbefcffe1b528/samples/container/Containers.md