### PR TITLE
Remove apt-get clean from RUN steps

### DIFF
--- a/builder.Dockerfile
+++ b/builder.Dockerfile
@@ -11,8 +11,6 @@ RUN apt-get update \
  && apt-get install --yes --no-install-recommends \
     tar \
     xz-utils \
-### Cleanup
- && apt-get clean \
  && rm --recursive --force /var/lib/apt/lists/* \
 ### extract Linaro GCC
  && tar --extract --xz --file gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf.tar.xz \
@@ -38,8 +36,6 @@ RUN apt-get update \
     xz-utils \
 ### add armhf as target to rust
  && rustup target add arm-unknown-linux-gnueabihf \
-### clean up stuff
- && apt-get clean \
  && rm --recursive --force /var/lib/apt/lists/*
 
 WORKDIR /usr/src/plato

--- a/emulator.Dockerfile
+++ b/emulator.Dockerfile
@@ -47,8 +47,6 @@ FROM rust:1.87-slim-bookworm AS plato-emulator-base
         libgumbo-dev \
         libopenjp2-7-dev \
         libjbig2dec0-dev \
-     ## clean up
-     && apt-get clean \
      && rm --recursive --force /var/lib/apt/lists/*
 
     WORKDIR /usr/src/plato


### PR DESCRIPTION
Removed `apt-get clean` from the RUN steps because of [Docker's Best Practices for Building recommendation](https://docs.docker.com/build/building/best-practices/#apt-get) about apt-get.

Link for `apt-get clean` is a bit old on Docker's documentation at the moment and Rust uses Debian as a base, so you can look for the current state on debuerreotype: https://github.com/debuerreotype/debuerreotype/blob/ccebaf5/scripts/debuerreotype-minimizing-config#L87-L109