### PR TITLE
Use leaner and simpler emulator image with 2 stages

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Emulator and builder Docker containers for [Plato](https://github.com/baskervill
 
 The `Plato` Docker images are designed as `development containers`, designed to minimize `cargo build` time during the container execution time, to compile and test `Plato`'s code as fast as possible.
 
-Currently, Docker images are prototypes and work-in-progress; the Docker images are fat (`builder`: ~1.8GB, `emulator`: ~3.1GB), `docker build` can take a long time and the containers probably run with more than necessary [options](https://docs.docker.com/engine/reference/run/#options).
+Currently, Docker images are somewhat optimized and work-in-progress; but the Docker images are fat (`builder`: ~1.8GB, `emulator`: ~2.5GB), `docker build` can take a long time and the containers probably run with more than necessary [options](https://docs.docker.com/engine/reference/run/#options).
 
 ## Motivation
 
@@ -16,7 +16,7 @@ Inspired by [Jessie Frazelle](https://github.com/jessfraz)'s old blog post about
 
 ## Usage
 
-Initially, get the original `Plato` repo:
+Initially, clone this repo and then get the original `Plato` repo with:
 ```sh
 $ cd plato-in-container
 $ git submodule update --init
@@ -26,22 +26,25 @@ $ git submodule update --init
 
 For building and getting the package ready for using on Kobo e-readers:
 ```sh
-$ docker compose build plato-builder
 $ docker compose run --rm plato-builder
 ```
 or
 
 ```sh
-$ docker compose build
 $ docker compose run --rm plato-builder bash
-in-container$ ./build.sh && ./dist.sh
+# ./build.sh && ./dist.sh
 ```
 
 ### Emulator
 
 For running the emulator and accessing the graphics device inside the container:
 ```sh
-$ docker compose build plato-emulator
+$ docker compose run --rm plato-emulator bash
+# ./run-emulator.sh
+```
+or
+
+```sh
 $ docker compose run --rm plato-emulator
 ```
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -27,8 +27,4 @@ services:
       - ./logs:/usr/src/plato/logs
       # WSLg reference: github.com/microsoft/wslg/blob/d14b392/samples/container/Containers.md
       - /tmp/.X11-unix:/tmp/.X11-unix
-    develop:
-      watch:
-        - action: sync+restart
-          path: ./plato/crates/
-          target: /usr/src/plato/crates/
+      - ./plato/crates:/usr/src/plato/crates:ro

--- a/emulator.Dockerfile
+++ b/emulator.Dockerfile
@@ -27,10 +27,16 @@ FROM rust:1.87-slim-bookworm AS mupdf-libs
      && cd mupdf-${MUPDF_VERSION}-source \
      && make HAVE_X11=no HAVE_GLUT=no prefix=/usr/local install-libs
 
-FROM rust:1.87-slim-bookworm AS plato-emulator-base
+FROM rust:1.87-slim-bookworm AS plato-emulator
+
+    ARG MUPDF_VERSION
 
     COPY --from=mupdf-libs /usr/local/lib/ /usr/local/lib/
     COPY --from=mupdf-libs /usr/local/include/ /usr/local/include/
+
+    WORKDIR /usr/src/plato
+    COPY . /usr/src/plato
+    COPY --from=mupdf-libs /mupdf-${MUPDF_VERSION}-source.tar.gz /usr/src/plato/thirdparty/
 
     RUN apt-get update \
      && apt-get install --yes --no-install-recommends \
@@ -41,36 +47,19 @@ FROM rust:1.87-slim-bookworm AS plato-emulator-base
         libopenjp2-7-dev \
         libsdl2-dev \
         libstdc++-12-dev \
-     && rm --recursive --force /var/lib/apt/lists/*
-
-    WORKDIR /usr/src/plato
-
-FROM plato-emulator-base AS plato-emulator-libs
-
-    ARG MUPDF_VERSION
-
-    COPY . .
-    COPY --from=mupdf-libs /mupdf-${MUPDF_VERSION}-source.tar.gz /usr/src/plato/thirdparty/
-
-    RUN cd /usr/src/plato/thirdparty/ \
+     && rm --recursive --force /var/lib/apt/lists/* \
+     ## extract MuPDF files
+     && cd /usr/src/plato/thirdparty/ \
      && mkdir -p mupdf \
      && tar -xz --strip-components 1 --directory mupdf \
         --file mupdf-${MUPDF_VERSION}-source.tar.gz \
-     && rm --verbose mupdf-${MUPDF_VERSION}-source.tar.gz
-
-    RUN cd /usr/src/plato/mupdf_wrapper \
+     && rm --verbose mupdf-${MUPDF_VERSION}-source.tar.gz \
+     ## Build MuPDF wrapper
+     && cd /usr/src/plato/mupdf_wrapper \
      && ./build.sh \
+     ## Build Plato Emulator
      && cd /usr/src/plato \
      && cargo test \
      && cargo build --all-features
-
-FROM plato-emulator-base AS plato-emulator
-
-    # Rust crate caching:
-    # https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci
-    COPY --from=plato-emulator-libs $CARGO_HOME/registry/index/ $CARGO_HOME/registry/index/
-    COPY --from=plato-emulator-libs $CARGO_HOME/registry/cache/ $CARGO_HOME/registry/cache/
-
-    COPY --from=plato-emulator-libs /usr/src/plato/ /usr/src/plato/
 
     CMD [ "./run-emulator.sh" ]


### PR DESCRIPTION
- Smaller image size: from 3.18GB to 2.48GB
- Faster compilation time: from 55 seconds to 19 seconds
- Use 2 less layers that comes from ARG and COPY layers
- One less intermediary image stage
- Easier compose use with just volume for source code