### PR TITLE
Update compose file for current `plato-builder` usage

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -3,11 +3,7 @@ services:
     image: ghcr.io/randomnoise/plato-builder:latest
     volumes:
       - ./dist:/usr/src/plato/dist
-    develop:
-      watch:
-        - action: sync+restart
-          path: ./plato/crates/
-          target: /usr/src/plato/crates/
+      - ./plato/crates:/usr/src/plato/crates:ro
 
   plato-emulator:
     image: ghcr.io/randomnoise/plato-emulator:latest

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,9 +1,6 @@
 services:
   plato-builder:
-    build:
-      context: ./plato
-      dockerfile: ../builder.Dockerfile
-    image: local-plato:builder
+    image: ghcr.io/randomnoise/plato-builder:latest
     volumes:
       - ./dist:/usr/src/plato/dist
     develop:

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,7 +6,6 @@ services:
     image: local-plato:builder
     volumes:
       - ./dist:/usr/src/plato/dist
-      - ./logs:/usr/src/plato/logs
     develop:
       watch:
         - action: sync+restart
@@ -24,7 +23,6 @@ services:
     volumes:
       - ~/.Xauthority:/root/.Xauthority
       - /etc/localtime:/etc/localtime:ro
-      - ./logs:/usr/src/plato/logs
       # WSLg reference: github.com/microsoft/wslg/blob/d14b392/samples/container/Containers.md
       - /tmp/.X11-unix:/tmp/.X11-unix
       - ./plato/crates:/usr/src/plato/crates:ro


### PR DESCRIPTION
- Removed log volumes: it should be optional for local user
- Use the already built image from the GitHub container registry for `plato-builder`
- Gave up on `syn + restart` watch mode: I find volumes to create tighter development loops