### PR TITLE
Move Docker image from `bookworm` to `trixie`

### DIFF
--- a/builder.Dockerfile
+++ b/builder.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM rust:1.90-slim-bookworm AS linaro-files
+FROM rust:1.90-slim AS linaro-files
 
 # Linaro GCC's checksum is same with the Kobo Reader's toolchain Git LFS file reference:
 # https://github.com/kobolabs/Kobo-Reader/blob/master/toolchain/gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf.tar.xz
@@ -17,7 +17,7 @@ RUN apt-get update \
  && mv --verbose /gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf/ /gcc-linaro/ \
  && rm --verbose /gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf.tar.xz
 
-FROM rust:1.90-slim-bookworm
+FROM rust:1.90-slim
 
 # add Linaro GCC to $PATH
 COPY --from=linaro-files /gcc-linaro/ /gcc-linaro/

--- a/emulator.Dockerfile
+++ b/emulator.Dockerfile
@@ -4,7 +4,7 @@ ARG MUPDF_VERSION=1.23.11
 # sha1 checksum: https://mupdf.com/releases/
 ARG MUPDF_FILE_CHECKSUM=ec9e63a7cdd0f50569f240f91f048f37fa972c47
 
-FROM rust:1.90-slim-bookworm AS mupdf-libs
+FROM rust:1.90-slim AS mupdf-libs
 
     ARG MUPDF_VERSION MUPDF_FILE_CHECKSUM
 
@@ -26,7 +26,7 @@ FROM rust:1.90-slim-bookworm AS mupdf-libs
      && cd mupdf-${MUPDF_VERSION}-source \
      && make HAVE_X11=no HAVE_GLUT=no prefix=/usr/local install-libs
 
-FROM rust:1.90-slim-bookworm AS plato-emulator
+FROM rust:1.90-slim AS plato-emulator
 
     COPY --from=mupdf-libs /usr/local/lib/ /usr/local/lib/
     COPY --from=mupdf-libs /usr/local/include/mupdf/ /usr/local/include/mupdf/
@@ -46,7 +46,7 @@ FROM rust:1.90-slim-bookworm AS plato-emulator
         libjbig2dec0-dev \
         libopenjp2-7-dev \
         libsdl2-dev \
-        libstdc++-12-dev \
+        libstdc++-14-dev \
         wget \
      && rm --recursive --force /var/lib/apt/lists/* \
      ## download and extract MuPDF files


### PR DESCRIPTION
- Just `rust:*-slim` images instead of `rust:*-slim-bookworm`
- Use `libstdc++-14-dev` instead of `libstdc++-12-dev`