### PR TITLE
Move back to `debian:bookworm` to fix visual rendering on MuPDF binaries and Plato emulator

### DIFF
--- a/builder.Dockerfile
+++ b/builder.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM rust:1.92-slim AS linaro-files
+FROM rust:1.92-slim-bookworm AS linaro-files
 
 # Linaro GCC's checksum is same with the Kobo Reader's toolchain Git LFS file reference:
 # https://github.com/kobolabs/Kobo-Reader/blob/master/toolchain/gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf.tar.xz
@@ -19,7 +19,7 @@ RUN apt-get update \
  && mv --verbose /gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf/ /gcc-linaro/ \
  && rm --verbose /gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf.tar.xz
 
-FROM rust:1.92-slim
+FROM rust:1.92-slim-bookworm
 
 # add Linaro GCC to $PATH
 COPY --from=linaro-files /gcc-linaro/ /gcc-linaro/

--- a/emulator.Dockerfile
+++ b/emulator.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM rust:1.92-slim AS mupdf-libs
+FROM rust:1.92-slim-bookworm AS mupdf-libs
 
     ARG MUPDF_VERSION=1.27.0
 
@@ -20,7 +20,7 @@ FROM rust:1.92-slim AS mupdf-libs
      && cd mupdf-${MUPDF_VERSION}-source \
      && make HAVE_X11=no HAVE_GLUT=no prefix=/usr/local install-libs
 
-FROM rust:1.92-slim AS plato-emulator
+FROM rust:1.92-slim-bookworm AS plato-emulator
 
     COPY --from=mupdf-libs /usr/local/lib/ /usr/local/lib/
     COPY --from=mupdf-libs /usr/local/include/mupdf/ /usr/local/include/mupdf/
@@ -40,7 +40,7 @@ FROM rust:1.92-slim AS plato-emulator
         libjbig2dec0-dev \
         libopenjp2-7-dev \
         libsdl2-dev \
-        libstdc++-14-dev \
+        libstdc++-12-dev \
         wget \
      && rm --recursive --force /var/lib/apt/lists/* \
      ## download and extract MuPDF files

--- a/emulator.Dockerfile
+++ b/emulator.Dockerfile
@@ -34,6 +34,7 @@ FROM rust:1.92-slim-bookworm AS plato-emulator
     RUN apt-get update \
      && apt-get install --yes --no-install-recommends \
         git \
+        libbz2-dev \
         libdjvulibre-dev \
         libgumbo-dev \
         libharfbuzz-dev \

--- a/emulator.Dockerfile
+++ b/emulator.Dockerfile
@@ -22,7 +22,7 @@ FROM rust:1.92-slim-bookworm AS mupdf-libs
 
 FROM rust:1.92-slim-bookworm AS plato-emulator
 
-    COPY --from=mupdf-libs /usr/local/lib/ /usr/local/lib/
+    COPY --from=mupdf-libs /usr/local/lib/libmupdf*.a /usr/local/lib/
     COPY --from=mupdf-libs /usr/local/include/mupdf/ /usr/local/include/mupdf/
 
     COPY . /usr/src/plato

--- a/experimental/compose.yaml
+++ b/experimental/compose.yaml
@@ -14,3 +14,16 @@ services:
       - ~/.Xauthority:/root/.Xauthority
       - /etc/localtime:/etc/localtime:ro
       # - /tmp/.X11-unix:/tmp/.X11-unix
+  mupdf:
+    build:
+      context: .
+      dockerfile: mupdf.Dockerfile
+    image: local-mupdf-test
+    devices:
+      - /dev/dri
+    environment:
+      - DISPLAY=unix${DISPLAY}
+    network_mode: "host"
+    volumes:
+      - ~/.Xauthority:/root/.Xauthority
+      # - /tmp/.X11-unix:/tmp/.X11-unix

--- a/experimental/mupdf.Dockerfile
+++ b/experimental/mupdf.Dockerfile
@@ -14,7 +14,7 @@ ARG MUPDF_SHA256_CHECKSUM=ae2442416de499182d37a526c6fa2bacc7a3bed5a888d113ca0484
 FROM debian:bookworm AS build-mupdf
 
 ### MuPDF dependencies:
-### https://mupdf.readthedocs.io/en/latest/quick-start-guide.html#linux
+### https://mupdf.readthedocs.io/en/latest/guide/install.html#build-on-linux-and-bsd-and-macos
 RUN apt-get update \
  && apt-get install --yes --no-install-recommends \
     g++ \
@@ -33,7 +33,8 @@ ARG MUPDF_VERSION MUPDF_SHA256_CHECKSUM
 ADD --checksum=sha256:${MUPDF_SHA256_CHECKSUM} \
     https://mupdf.com/downloads/archive/mupdf-${MUPDF_VERSION}-source.tar.gz /
 
-### extract and build MuPDF
+### extract and build MuPDF:
+### https://mupdf.readthedocs.io/en/latest/guide/install.html#install-on-linux
 RUN tar --extract --gzip --file mupdf-${MUPDF_VERSION}-source.tar.gz \
  && cd mupdf-${MUPDF_VERSION}-source \
  && make prefix=/usr/local install

--- a/experimental/mupdf.Dockerfile
+++ b/experimental/mupdf.Dockerfile
@@ -50,6 +50,6 @@ RUN apt-get update \
     libsdl2-dev \
  && rm --recursive --force /var/lib/apt/lists/*
 
-COPY --from=build-mupdf /usr/local/bin/ /usr/local/bin/
 COPY --from=build-mupdf /usr/local/lib/ /usr/local/lib/
 COPY --from=build-mupdf /usr/local/include/mupdf/ /usr/local/include/mupdf/
+COPY --from=build-mupdf /usr/local/bin/ /usr/local/bin/

--- a/experimental/mupdf.Dockerfile
+++ b/experimental/mupdf.Dockerfile
@@ -1,0 +1,55 @@
+# syntax=docker/dockerfile:1
+
+ARG MUPDF_VERSION=1.27.0
+ARG MUPDF_SHA256_CHECKSUM=ae2442416de499182d37a526c6fa2bacc7a3bed5a888d113ca04844484dfe7c6
+
+# Previous MuPDF version (1.23.11) Plato used also worked
+# in this context with bookworm:
+# ARG MUPDF_VERSION=1.23.11 \
+#     MUPDF_SHA256_CHECKSUM=478f2a167feae2a291c8b8bc5205f2ce2f09f09b574a6eb0525bfad95a3cfe66
+
+# TODO: couldn't figure out the reason but 2 MuPDF versions (MuPDF versions 1.23.11 and 1.27.0)
+# didn't work with Debian 13 Trixie:
+# FROM debian:trixie
+FROM debian:bookworm AS build-mupdf
+
+### MuPDF dependencies:
+### https://mupdf.readthedocs.io/en/latest/quick-start-guide.html#linux
+RUN apt-get update \
+ && apt-get install --yes --no-install-recommends \
+    g++ \
+    libgl1-mesa-dev \
+    libglu1-mesa-dev \
+    libxcursor-dev \
+    libxinerama-dev \
+    libxrandr-dev \
+    make \
+    mesa-common-dev \
+    xorg-dev \
+ && rm --recursive --force /var/lib/apt/lists/*
+
+ARG MUPDF_VERSION MUPDF_SHA256_CHECKSUM
+
+ADD --checksum=sha256:${MUPDF_SHA256_CHECKSUM} \
+    https://mupdf.com/downloads/archive/mupdf-${MUPDF_VERSION}-source.tar.gz /
+
+### extract and build MuPDF
+RUN tar --extract --gzip --file mupdf-${MUPDF_VERSION}-source.tar.gz \
+ && cd mupdf-${MUPDF_VERSION}-source \
+ && make prefix=/usr/local install
+
+FROM debian:bookworm AS visual-dependencies
+
+RUN apt-get update \
+ && apt-get install --yes --no-install-recommends \
+    libdjvulibre-dev \
+    libgumbo-dev \
+    libharfbuzz-dev \
+    libjbig2dec0-dev \
+    libopenjp2-7-dev \
+    libsdl2-dev \
+ && rm --recursive --force /var/lib/apt/lists/*
+
+COPY --from=build-mupdf /usr/local/bin/ /usr/local/bin/
+COPY --from=build-mupdf /usr/local/lib/ /usr/local/lib/
+COPY --from=build-mupdf /usr/local/include/mupdf/ /usr/local/include/mupdf/

--- a/experimental/mupdf.Dockerfile
+++ b/experimental/mupdf.Dockerfile
@@ -42,12 +42,13 @@ FROM debian:bookworm AS visual-dependencies
 
 RUN apt-get update \
  && apt-get install --yes --no-install-recommends \
-    libdjvulibre-dev \
-    libgumbo-dev \
-    libharfbuzz-dev \
-    libjbig2dec0-dev \
-    libopenjp2-7-dev \
-    libsdl2-dev \
+ ## mupdf-x11 dependencies:
+    libx11-6 \
+    libxext6 \
+ ## mupdf-gl dependencies:
+ ## libx11-6 and libxext6 are also included in libgl1
+    libgl1 \
+    libxrandr2 \
  && rm --recursive --force /var/lib/apt/lists/*
 
 COPY --from=build-mupdf /usr/local/lib/libmupdf*.a /usr/local/lib/

--- a/experimental/mupdf.Dockerfile
+++ b/experimental/mupdf.Dockerfile
@@ -50,6 +50,6 @@ RUN apt-get update \
     libsdl2-dev \
  && rm --recursive --force /var/lib/apt/lists/*
 
-COPY --from=build-mupdf /usr/local/lib/ /usr/local/lib/
+COPY --from=build-mupdf /usr/local/lib/libmupdf*.a /usr/local/lib/
 COPY --from=build-mupdf /usr/local/include/mupdf/ /usr/local/include/mupdf/
 COPY --from=build-mupdf /usr/local/bin/ /usr/local/bin/


### PR DESCRIPTION
Currently unknown reasons, visual components of MuPDF binaries and `plato` emulator doesn't work on `debian:trixie`.

So, let's move back to `bookworm` for a time, and if we discover the underlying cause for the visual rendering errors, we can move to `trixie`.