### PR TITLE
Use alternative link for Linaro GCC file

### DIFF
--- a/builder.Dockerfile
+++ b/builder.Dockerfile
@@ -4,8 +4,10 @@ FROM rust:1.92-slim AS linaro-files
 
 # Linaro GCC's checksum is same with the Kobo Reader's toolchain Git LFS file reference:
 # https://github.com/kobolabs/Kobo-Reader/blob/master/toolchain/gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf.tar.xz
+# Alternative Linaro GCC link:
+# https://releases.linaro.org/components/toolchain/binaries/4.9-2017.01/arm-linux-gnueabihf/gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf.tar.xz
 ADD --checksum=sha256:22914118fd963f953824b58107015c6953b5bbdccbdcf25ad9fd9a2f9f11ac07 \
-    https://releases.linaro.org/components/toolchain/binaries/4.9-2017.01/arm-linux-gnueabihf/gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf.tar.xz /
+    https://developer.arm.com/-/cdn-downloads/permalink/legacy-linaro-gnu-toolchains/4.9-2017.01/gcc-linaro-4.9.4-2017.01-x86_64_arm-linux-gnueabihf.tar.xz /
 
 RUN apt-get update \
  && apt-get install --yes --no-install-recommends \


### PR DESCRIPTION
https://releases.linaro.org/ started giving errors so switched to Arm Developer link for Linaro GCC file 

Reference: [github.com/OGKevin/cadmus/blob/7b6062b/devenv.nix#L145-L146](https://github.com/OGKevin/cadmus/blob/7b6062bbce8183b59ca2c1379225f1767fef159f/devenv.nix#L145-L146)