### PR TITLE
Move MuPDF variables to top of file as `ARG`

### DIFF
--- a/emulator.Dockerfile
+++ b/emulator.Dockerfile
@@ -1,7 +1,10 @@
 # syntax=docker/dockerfile:1
+
+ARG MUPDF_VERSION=1.27.0
+
 FROM rust:1.92-slim-bookworm AS mupdf-libs
 
-    ARG MUPDF_VERSION=1.27.0
+    ARG MUPDF_VERSION
 
     # sha256 checksum: https://mupdf.com/releases/
     ADD --checksum=sha256:ae2442416de499182d37a526c6fa2bacc7a3bed5a888d113ca04844484dfe7c6 \

--- a/emulator.Dockerfile
+++ b/emulator.Dockerfile
@@ -1,13 +1,14 @@
 # syntax=docker/dockerfile:1
 
 ARG MUPDF_VERSION=1.27.0
+### sha256 checksum: https://mupdf.com/releases/
+ARG MUPDF_SHA256_CHECKSUM=ae2442416de499182d37a526c6fa2bacc7a3bed5a888d113ca04844484dfe7c6
 
 FROM rust:1.92-slim-bookworm AS mupdf-libs
 
-    ARG MUPDF_VERSION
+    ARG MUPDF_VERSION MUPDF_SHA256_CHECKSUM
 
-    # sha256 checksum: https://mupdf.com/releases/
-    ADD --checksum=sha256:ae2442416de499182d37a526c6fa2bacc7a3bed5a888d113ca04844484dfe7c6 \
+    ADD --checksum=sha256:${MUPDF_SHA256_CHECKSUM} \
         https://mupdf.com/downloads/archive/mupdf-${MUPDF_VERSION}-source.tar.gz /
 
     ### MuPDF dependencies:


### PR DESCRIPTION
Make MuPDF information more visible by making them `ARG` variables and moving them up to the top of the `emulator.Dockerfile`