### PR TITLE
Check Github Actions versions with dependabot weekly

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,3 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Current versions of Github actions are getting Nodejs version 20 depreciation notices. I have missed the updates, dependabot warnings would be nice.